### PR TITLE
Roll back to `moduleResolution="node"`

### DIFF
--- a/.changeset/tender-kangaroos-jam.md
+++ b/.changeset/tender-kangaroos-jam.md
@@ -1,0 +1,5 @@
+---
+"@finsweet/tsconfig": patch
+---
+
+Roll back to `moduleResolution="node"` because it seems that many libraries still don't support the new `bundler` option.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,7 @@
     "verbatimModuleSyntax": true,
 
     /* Module Resolution Options */
-    "moduleResolution": "bundler",
+    "moduleResolution": "node",
     "resolveJsonModule": true,
 
     /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */


### PR DESCRIPTION
Roll back to `moduleResolution="node"` because it seems that many libraries still don't support the new `bundler` option.